### PR TITLE
Added rebuild-sqlite3-win script for windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 Example electron app with sqlite3 integration
 
 Based on the approach in https://github.com/atom/electron/issues/1182 and http://verysimple.com/2015/05/30/using-node_sqlite3-with-electron/
+
+For windows the line in package.json:
+````
+"postinstall": "npm run rebuild-sqlite3",
+````
+can be changed to:
+````
+"postinstall": "npm run rebuild-sqlite3-win",
+````
+or alternatively just run
+````
+npm run rebuild-sqlite3-win
+````

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "start": "electron .",
     "build": "electron-packager . electron-sqlite3 --out=dist --ignore=dist --prune --asar --all --version=0.36.4",
     "postinstall": "npm run rebuild-sqlite3",
-    "rebuild-sqlite3": "cd node_modules/sqlite3 && npm run prepublish && node-gyp configure --module_name=node_sqlite3 --module_path=../lib/binding/node-v47-darwin-x64 && node-gyp rebuild --target=0.36.4 --arch=x64 --target_platform=darwin --dist-url=https://atom.io/download/atom-shell --module_name=node_sqlite3 --module_path=../lib/binding/node-v47-darwin-x64"
+    "rebuild-sqlite3": "cd node_modules/sqlite3 && npm run prepublish && node-gyp configure --module_name=node_sqlite3 --module_path=../lib/binding/node-v47-darwin-x64 && node-gyp rebuild --target=0.36.4 --arch=x64 --target_platform=darwin --dist-url=https://atom.io/download/atom-shell --module_name=node_sqlite3 --module_path=../lib/binding/node-v47-darwin-x64",
+    "rebuild-sqlite3-win": "cd node_modules/sqlite3 && npm run prepublish && node-gyp configure --module_name=node_sqlite3 --module_path=../lib/binding/node-v47-win32-x64 && node-gyp node-gyp rebuild --target=0.36.0 --arch=x64 --target_platform=win32 --dist-url=https://atom.io/download/atom-shell --module_name=node_sqlite3 --module_path=../lib/binding/node-v47-win32-x64"
   },
   "author": "Ben Bytheway",
   "contributors": [],


### PR DESCRIPTION
Simple change adding "rebuild-sqlite3-win" script to run on windows, updated the readme to describe how to run that script or change the postinstall script to run rebuild-sqlite3-win instead of rebuild-sqlite3.

Note the script still assumes darwin so will work on the mac as before.